### PR TITLE
feat: allow app to boot without payment config

### DIFF
--- a/app/Services/PaymentService.php
+++ b/app/Services/PaymentService.php
@@ -22,7 +22,11 @@ class PaymentService
      */
     public function createPayment(array $data): Payment
     {
-        $provider = $data['provider'] ?? config('payments.default_provider', 'yookassa');
+        $provider = $data['provider'] ?? config('payments.default_provider');
+
+        if (!$provider || !config("payments.providers.{$provider}.enabled")) {
+            throw new RuntimeException('Платежный провайдер не настроен');
+        }
 
         return match ($provider) {
             'yookassa' => $this->yooKassaService->createPayment($data),


### PR DESCRIPTION
## Summary
- avoid crashing when payment provider config missing
- disable payments and warn when provider not configured

## Testing
- `composer install` *(fails: Authentication required (git.yoomoney.ru))*
- `php artisan --version` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a4c21c908323b9c06991c4339ab4