### PR TITLE
fix: implement FilamentUser in User model

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -10,8 +10,9 @@ use Laravel\Fortify\TwoFactorAuthenticatable;
 use Laravel\Jetstream\HasProfilePhoto;
 use Laravel\Sanctum\HasApiTokens;
 use Spatie\Permission\Traits\HasRoles;
+use Filament\Models\Contracts\FilamentUser;
 
-class User extends Authenticatable
+class User extends Authenticatable implements FilamentUser
 {
     use HasApiTokens;
 


### PR DESCRIPTION
## Summary
- implement FilamentUser interface on User model so Filament can evaluate `canAccessPanel`

## Testing
- `composer install`
- `php artisan test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b9df6b912083238122cddf71ef76f3